### PR TITLE
modified 4xx error determination

### DIFF
--- a/v2/python/all-sites-entry-count/retrieve-counts.py
+++ b/v2/python/all-sites-entry-count/retrieve-counts.py
@@ -26,7 +26,7 @@ def query_api(url):
     try:
         response = urllib2.urlopen(request)
     except urllib2.HTTPError as err:
-        if err.getcode()/10*10 == 400:
+        if err.getcode()/100*100 == 400:
             content = json.loads(err.read())
             error_msgs = ', '.join(content['error_messages'])
             raise Exception('API responded with 4XX error: %s' % error_msgs)


### PR DESCRIPTION
Hello!

I came across a small discrepancy while reading through the v2 API example integration. On line 29 in the query_api function, some math is used to determine if the HTTP error is a 4XX client error. The current implementation will not recognize client errors greater than 409 as the math will not produce a value equal to the required 400. Consequently, the 4XX exception message on line 32 will not be raised for those status codes. By changing the math to use 100's instead of 10's, the full range of 4XX status codes will be captured.

Sincerely,

Jeff Wen
